### PR TITLE
Add Dependabot configuration file

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "06:00"
+    open-pull-requests-limit: 10

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -6,3 +6,9 @@ updates:
       interval: daily
       time: "06:00"
     open-pull-requests-limit: 10
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "06:00"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
This pull request adds a Dependabot configuration file to the repository. The configuration file specifies that Dependabot should check for updates to the GitHub Actions package ecosystem on a daily basis at 06:00. Additionally, it sets a limit of 10 open pull requests for Dependabot. This configuration will help ensure that the repository stays up to date with the latest versions of GitHub Actions and Pip and prevent an excessive number of open pull requests.