### PR TITLE
Refactor MicrosoftSTT fixture to return arguments

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,15 +2,14 @@
 
 from types import SimpleNamespace
 import pytest
-from wyoming_microsoft_stt.microsoft_stt import MicrosoftSTT
 import os
 
 
 @pytest.fixture
-def microsoft_stt():
+def microsoft_stt_args():
     """Return MicrosoftSTT instance."""
     args = SimpleNamespace(
         subscription_key=os.environ.get("SPEECH_KEY"),
         service_region=os.environ.get("SPEECH_REGION"),
     )
-    return MicrosoftSTT(args)
+    return args

--- a/tests/test_microsoft_stt.py
+++ b/tests/test_microsoft_stt.py
@@ -1,13 +1,18 @@
 """Tests for the MicrosoftTTS class."""
 
+from wyoming_microsoft_stt.microsoft_stt import MicrosoftSTT
 
-def test_initialize(microsoft_stt):
+
+def test_initialize(microsoft_stt_args):
     """Test initialization."""
+    microsoft_stt = MicrosoftSTT(microsoft_stt_args)
     assert microsoft_stt.speech_config is not None
 
 
-def test_transcribe(microsoft_stt):
+def test_transcribe(microsoft_stt_args):
     """Test synthesize."""
+    microsoft_stt = MicrosoftSTT(microsoft_stt_args)
+
     filename = "./tests/hello_world.wav"
     language = "en-GB"
 


### PR DESCRIPTION
Update the MicrosoftSTT fixture to return the necessary arguments instead of an instance, simplifying the test setup. Adjust tests to utilize the new fixture format.