### PR TITLE
fix: profanity filter should be `off` not `raw`

### DIFF
--- a/wyoming_microsoft_stt/__main__.py
+++ b/wyoming_microsoft_stt/__main__.py
@@ -59,7 +59,7 @@ def parse_arguments():
     parser.add_argument(
         "--profanity",
         default="masked",
-        choices=["masked", "removed", "raw"],
+        choices=["masked", "removed", "off"],
         help="Profanity setting for speech recognition",
     )
     parser.add_argument("--debug", action="store_true", help="Log DEBUG messages")


### PR DESCRIPTION
Change the profanity filter option from `raw` to `off` in the argument parser for speech recognition.