### PR TITLE
fix: ensure graceful shutdown by exiting after stop signal

### DIFF
--- a/wyoming_microsoft_stt/__main__.py
+++ b/wyoming_microsoft_stt/__main__.py
@@ -25,6 +25,7 @@ def handle_stop_signal(*args):
     """Handle shutdown signal and set the stop event."""
     _LOGGER.info("Received stop signal. Shutting down...")
     stop_event.set()
+    exit()
 
 
 def parse_arguments():


### PR DESCRIPTION
Implement an immediate exit after receiving a stop signal to ensure a graceful shutdown of the application.